### PR TITLE
Fix: Adjust button layout on small screens

### DIFF
--- a/App.js
+++ b/App.js
@@ -1275,10 +1275,12 @@ function ScoreboardApp({ roomId, onLeaveRoom, onSignOut, user, db }) {
         <div className="bg-gray-900 text-white min-h-screen font-sans p-4 sm:p-6 lg:p-8">
             {modal && <Modal {...modal} />}
             <div className="max-w-full mx-auto">
-                <header className="text-center mb-8 relative">
-                    <h1 className="text-4xl sm:text-5xl font-bold text-blue-400 tracking-wider"><TrophyIcon /> Akavin games</h1>
-                    <p className="text-gray-400 mt-2">AkaGamestudio © v0.1</p>
-                    <div className="absolute top-0 right-0 flex items-start gap-4">
+                <header className="mb-8 relative flex flex-col sm:flex-row sm:justify-center items-center">
+                    <div className="text-center">
+                        <h1 className="text-4xl sm:text-5xl font-bold text-blue-400 tracking-wider"><TrophyIcon /> Akavin games</h1>
+                        <p className="text-gray-400 mt-2">AkaGamestudio © v0.1</p>
+                    </div>
+                    <div className="sm:absolute sm:top-0 sm:right-0 flex items-start gap-4 mt-4 sm:mt-0">
                          {user && !user.isAnonymous && (
                              <button onClick={onSignOut} className="bg-gray-700 text-white font-bold py-2 px-4 rounded-md hover:bg-gray-600 flex items-center">
                                 <LogoutIcon /> Sign Out


### PR DESCRIPTION
The "Sign out" and "Leave Room" buttons were overlapping with the page title on smaller screen widths.

This change modifies the header to use a flexbox layout. On small screens, the header items are stacked vertically, with the buttons appearing below the title. On larger screens, the buttons are absolutely positioned to the top-right, as they were before.

This is achieved by using Tailwind CSS responsive utility classes.