### PR TITLE
Fix: Prevent buttons from overlapping title on small screens

### DIFF
--- a/App.js
+++ b/App.js
@@ -1156,7 +1156,7 @@ function JustFuTournament({ tournament, players, setTournament, onFinish, onCanc
 }
 
 // --- Main App Component ---
-function ScoreboardApp({ roomId, onLeaveRoom, onSignOut, user, db, setNeedsAvatar }) {
+function ScoreboardApp({ roomId, onLeaveRoom, onSignOut, user, db, setNeedsAvatar, executeAddPlayer }) {
     const appId = typeof __app_id !== 'undefined' ? __app_id : 'default-app-id';
 
     const [screen, setScreen] = useState('scoreboard');
@@ -1430,7 +1430,6 @@ function ScoreboardApp({ roomId, onLeaveRoom, onSignOut, user, db, setNeedsAvata
                     {user && !user.isAnonymous ? <p>Host: {user.displayName}</p> : <p>Guest User</p>}
                 </footer>
             </div>
-            <Footer onSignOut={onSignOut} onLeaveRoom={onLeaveRoom} roomId={roomId} user={user} />
         </div>
     );
 }
@@ -1630,7 +1629,12 @@ export default function App() {
     }
 
     if (roomId) {
-        return <ScoreboardApp roomId={roomId} onLeaveRoom={handleLeaveRoom} onSignOut={handleSignOut} user={user} db={firebaseServices.db} setNeedsAvatar={setNeedsAvatar} executeAddPlayer={executeAddPlayer} />;
+        return (
+            <>
+                <ScoreboardApp roomId={roomId} onLeaveRoom={handleLeaveRoom} onSignOut={handleSignOut} user={user} db={firebaseServices.db} setNeedsAvatar={setNeedsAvatar} executeAddPlayer={executeAddPlayer} />
+                <Footer onSignOut={handleSignOut} onLeaveRoom={handleLeaveRoom} roomId={roomId} user={user} />
+            </>
+        );
     }
 
     if (!user) {


### PR DESCRIPTION
The 'Sign out' and 'Leave Room' buttons were overlapping the title on smaller screen sizes. This was because the `Footer` component was rendered within the `ScoreboardApp` component, which has a layout that causes issues on smaller screens.

This commit moves the `Footer` component from the `ScoreboardApp` to the `App` component. This ensures that the footer is rendered outside of the `ScoreboardApp`'s layout, preventing the buttons from overlapping the title on any screen size.