### PR TITLE
Fix: Match avatar cropping on selection screen

### DIFF
--- a/App.js
+++ b/App.js
@@ -994,7 +994,7 @@ function AvatarSelection({ onAvatarSelect, onCancel, players }) {
                         <img
                             src={selectedAvatar}
                             alt="Avatar"
-                            className="w-full h-full object-contain"
+                            className="w-full h-full object-cover"
                         />
                     </div>
                     <button onClick={handleNext} className="text-4xl" disabled={availableAvatars.length < 2}>&rarr;</button>


### PR DESCRIPTION
This commit adjusts the styling of the avatar image on the avatar selection screen to match the cropping and aspect ratio of the avatars on the scoreboard.

The `object-contain` class has been replaced with `object-cover` on the `img` element in the `AvatarSelection` component. This ensures a consistent visual representation of avatars across the application.