### PR TITLE
Fix: Update 'Free for All' ranking logic to handle ties

### DIFF
--- a/App.js
+++ b/App.js
@@ -736,13 +736,27 @@ function FreeForAllGame({ tournament, setTournament, onFinish, onCancel }) {
         playersWithScores.sort((a, b) => b.score - a.score);
         
         const maxPoints = playersWithScores.length;
+        const results = [];
+        let rank = 1;
 
-        const results = playersWithScores.map((p, i) => ({
-            id: p.id,
-            name: p.name,
-            points: maxPoints - i,
-            rank: i + 1
-        }));
+        for (let i = 0; i < playersWithScores.length; i++) {
+            if (i > 0 && playersWithScores[i].score === playersWithScores[i - 1].score) {
+                results.push({
+                    id: playersWithScores[i].id,
+                    name: playersWithScores[i].name,
+                    points: maxPoints - results[i-1].rank + 1,
+                    rank: results[i-1].rank
+                });
+            } else {
+                rank = i + 1;
+                results.push({
+                    id: playersWithScores[i].id,
+                    name: playersWithScores[i].name,
+                    points: maxPoints - rank + 1,
+                    rank: rank
+                });
+            }
+        }
 
         setFinalResults({ gameName: 'Free For All', results, type: 'ffa' });
     };


### PR DESCRIPTION
This commit adjusts the ranking and point distribution logic for the 'Free for All' tournament mode.

When multiple players have the same score, they are now assigned the same rank. The points awarded to these tied players are based on the highest possible rank in their tied group, ensuring a fair and consistent outcome.