### PR TITLE
Fix: Correct syntax error in GameHistory component

### DIFF
--- a/App.js
+++ b/App.js
@@ -392,7 +392,7 @@ function GameHistory({ history, onBack, onDeleteGame, onRenameGame, isRoomCreato
                                 </span>
                                 <span className="text-right font-mono text-yellow-400">{r.points} pts</span>
                             </div>
-                        )}</div>
+                        )})}</div>
                     </div>
                 )) : <p className="text-center text-gray-400 py-8">No games recorded.</p>}
             </div>


### PR DESCRIPTION
This commit fixes a build failure caused by a syntax error in the `GameHistory` component. A missing closing parenthesis in the JSX mapping logic has been added, allowing the component to render correctly.